### PR TITLE
Switch from multirust to rustup as toolchain manager

### DIFF
--- a/lib/rustup-toolchain-view.coffee
+++ b/lib/rustup-toolchain-view.coffee
@@ -3,21 +3,21 @@ _ = require 'underscore-plus'
 {$, SelectListView} = require 'atom-space-pen-views'
 
 module.exports =
-class MultirustToolchainView extends SelectListView
+class RustUpToolchainView extends SelectListView
   previouslyFocusedElement: null
   cmd: null
   items: null
-  multirustBinPath: null
+  rustupBinPath: null
 
   constructor: (serializedState) ->
     super
 
   initialize: ->
     super
-    @multirustBinPath = atom.config.get("tokamak.multirustBinPath")
+    @rustupBinPath = atom.config.get("tokamak.rustupBinPath")
     @getToolchainList(@items, @toolchainExitCallback)
     @commandSubscription = atom.commands.add 'atom-workspace',
-    'tokamak:multirust-select-toolchain': => @attach()
+    'tokamak:rustup-select-toolchain': => @attach()
 
   attach: () ->
     @addClass('overlay from-top')
@@ -31,14 +31,14 @@ class MultirustToolchainView extends SelectListView
   changeToolchain: (item, callback) ->
       [responseSuccess, responseError] = ["", ""]
       @runCommandOut(
-        @multirustBinPath
+        @rustupBinPath
         ['default', item]
         stderr = (data) -> responseError += data.toString()
         stdout = (data) -> responseSuccess += data.toString()
         exit = (code) => callback(item, code, responseSuccess, responseError)
       )
 
-  multirustExitCallback: (item, code, stdoutData, stderrData) =>
+  rustupExitCallback: (item, code, stdoutData, stderrData) =>
     if code != 0
       atom.notifications.addError("Tokamak: Failed to change toolchain to #{item}", {
         detail: "#{stderrData}"
@@ -53,8 +53,8 @@ class MultirustToolchainView extends SelectListView
       @cmd = "Listing toolchains"
       [responseSuccess, responseError] = ["", ""]
       @runCommandOut(
-        @multirustBinPath
-        ['list-toolchains']
+        @rustupBinPath
+        ['toolchain', 'list']
         stderr = (data) -> responseError += data.toString()
         stdout = (data) -> responseSuccess += data.toString()
         exit = (code) => callback(@cmd, code, responseSuccess, responseError, @items)
@@ -76,7 +76,7 @@ class MultirustToolchainView extends SelectListView
 
   confirmed: (item) ->
     console.info("Tokamak: About the change toolchain #{item}")
-    @changeToolchain(item, @multirustExitCallback)
+    @changeToolchain(item, @rustupExitCallback)
 
   cancelled: ->
     console.log("This view was cancelled")

--- a/lib/tokamak.coffee
+++ b/lib/tokamak.coffee
@@ -1,6 +1,6 @@
 TokamakView = require './tokamak-view'
 CargoView = require './cargo-view'
-MultirustToolchainView = require './multirust-toolchain-view'
+RustUpToolchainView = require './rustup-toolchain-view'
 CreateProjectView = require './create-project-view'
 AboutView = require './about-view'
 
@@ -29,10 +29,10 @@ module.exports = Tokamak =
       type: 'string'
       default: '/usr/local/bin/cargo'
       order: 3
-    multirustBinPath:
-      title: 'Path to the Multirust rust installation manager'
+    rustupBinPath:
+      title: 'Path to the RustUp rust installation manager'
       type: 'string'
-      default: '/usr/local/bin/multirust'
+      default: '/usr/local/bin/rustup'
       order: 4
     racerBinPath:
       title: 'Path to the Racer executable'
@@ -68,7 +68,7 @@ module.exports = Tokamak =
 
   tokamakView: null
   cargoView: null
-  multirustToolchainView: null
+  rustupToolchainView: null
   createProjectView: null
   aboutView: null
 
@@ -79,7 +79,7 @@ module.exports = Tokamak =
   activate: (state) ->
     @tokamakView = new TokamakView(state.tokamakViewState)
     @cargoView = new CargoView(state.cargoViewState)
-    @multirustToolchainView = new MultirustToolchainView(state.multirustToolchainViewState)
+    @rustupToolchainView = new RustUpToolchainView(state.rustupToolchainViewState)
     @createProjectView = new CreateProjectView(state.createProjectView)
     @aboutView = new AboutView(state.aboutView)
 
@@ -151,7 +151,7 @@ module.exports = Tokamak =
 
     @toolBar.addButton
       icon: 'tools'
-      callback: 'tokamak:multirust-select-toolchain'
+      callback: 'tokamak:rustup-select-toolchain'
       tooltip: 'Change Rust Toolchain'
 
     @toolBar.addButton
@@ -173,7 +173,7 @@ module.exports = Tokamak =
     @modalPanel.destroy()
     @aboutModalPanel.destroy()
     @subscriptions.dispose()
-    @multirustToolchainView.destroy()
+    @rustupToolchainView.destroy()
     @cargoView.destroy()
     @tokamakView.destroy()
     @createProjectView.destroy()
@@ -183,7 +183,7 @@ module.exports = Tokamak =
   serialize: ->
     tokamakViewState: @tokamakView.serialize()
     cargoViewState: @cargoView.serialize()
-    multirustToolchainViewState: @multirustToolchainView.serialize()
+    rustupToolchainViewState: @rustupToolchainView.serialize()
     createProjectViewState: @createProjectView.serialize()
 
   toggle: (@modal)->

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -30,7 +30,7 @@ class Utils
           atom.notifications.addSuccess("Tokamak: Dependencies are installed!");
 
   @detectBinaries: ->
-    for pkg in ["cargo", "racer", "multirust", "rustc"]
+    for pkg in ["cargo", "racer", "rustup", "rustc"]
       console.log(pkg)
       data = @runCommandOut("which", [pkg])
       console.log(data)
@@ -42,8 +42,8 @@ class Utils
           when "racer"
             atom.config.set("tokamak.racerBinPath", data.stdoutData.replace(/^\s+|\s+$/g, ""))
             atom.config.set("racer.racerBinPath", data.stdoutData.replace(/^\s+|\s+$/g, ""))
-          when "multirust"
-            atom.config.set("tokamak.multirustBinPath", data.stdoutData.replace(/^\s+|\s+$/g, ""))
+          when "rustup"
+            atom.config.set("tokamak.rustupBinPath", data.stdoutData.replace(/^\s+|\s+$/g, ""))
           when "rustc"
             atom.config.set("tokamak.rustcBinPath", data.stdoutData.replace(/^\s+|\s+$/g, ""))
             atom.config.set("linter-rust.rustcPath", data.stdoutData.replace(/^\s+|\s+$/g, ""))


### PR DESCRIPTION
Not ready for merge. But a functional replacement of multirust with rustup.

How do you want to support rustup in the long run?