### PR TITLE
Implement automatic Rust source updating.

### DIFF
--- a/lib/source-updater-view.coffee
+++ b/lib/source-updater-view.coffee
@@ -1,0 +1,38 @@
+module.exports =
+class SourceUpdaterView
+  constructor: ->
+    @progressBar = document.createElement('progress')
+    @progressBar.style.width = '100%'
+
+    @stepProgress = 0
+
+    @element = atom.notifications.addInfo("Updating Rust source...", {
+      detail: "Initializing...",
+      dismissable: true
+      })
+
+    notificationView = atom.views.getView(@element)
+    detailContent = notificationView.querySelector('.detail-content')
+    detailContent.appendChild(@progressBar)
+    @detailText = detailContent.querySelector('.line')
+
+  updateState: (name) ->
+    @progressBar.value = 0
+    @progressBar.max = 0
+    @stepProgress = 0
+    @detailText.innerHTML = "#{@name}..."
+
+  setStepAmount: (size) ->
+    @progressBar.max = size
+
+  updateDownloadProgress: (bytesDownloaded = 0) ->
+    @stepProgress += bytesDownloaded
+    @progressBar.value = @stepProgress
+    downloadPercent = Math.trunc((@stepProgress / @progressBar.max) * 100.0)
+    @detailText.innerHTML = "Downloading... " + downloadPercent + "% completed."
+
+  updateExtractionProgress: (currentFile) ->
+    @detailText.innerHTML = "Extracting... " + currentFile
+
+  dismiss: ->
+    @element.dismiss()

--- a/lib/source-updater.coffee
+++ b/lib/source-updater.coffee
@@ -1,0 +1,48 @@
+fs = require 'fs-plus'
+request = require 'request'
+tar = require 'tar'
+zlib = require 'zlib'
+
+SourceUpdaterView = require './source-updater-view'
+
+module.exports =
+class SourceUpdater
+  @updateSourceFiles: ->
+    progressNotification = new SourceUpdaterView()
+    folder = fs.getAppDataDirectory() + "/tokamak/"
+    fs.mkdir(folder, (error) ->
+      out = fs.createWriteStream(folder + 'nightly_source.tar.gz');
+
+      req = request({
+          method: 'GET',
+          uri: 'https://static.rust-lang.org/dist/rustc-nightly-src.tar.gz'
+      })
+
+      req.pipe(out)
+
+      req.on('response', (data) ->
+        progressNotification.updateState("Downloading")
+        progressNotification.setStepAmount(data.headers['content-length'])
+      )
+
+      req.on('data', (chunk) ->
+        progressNotification.updateDownloadProgress(chunk.length)
+      )
+
+      req.on('end', ->
+        progressNotification.updateState("Extracting")
+        archivePath = folder + 'nightly_source.tar.gz'
+        sourceTar = fs.createReadStream(archivePath)
+        extractor = tar.Extract({path: folder + 'rust-sources'})
+                      .on('entry', (entry) -> progressNotification.updateExtractionProgress(entry.path))
+                      .on('error', (error) -> console.error(error))
+                      .on('end', ->
+                        atom.notifications.addSuccess("Successfully updated Rust's source!")
+                        progressNotification.dismiss()
+                      )
+
+        sourceTar
+          .pipe(zlib.createGunzip())
+          .pipe(extractor)
+      )
+    )

--- a/lib/tokamak.coffee
+++ b/lib/tokamak.coffee
@@ -5,6 +5,7 @@ CreateProjectView = require './create-project-view'
 AboutView = require './about-view'
 
 Utils = require './utils'
+SourceUpdater = require './source-updater'
 
 {consumeRunInTerminal} = require './terminal'
 {BufferedProcess, CompositeDisposable} = require 'atom'
@@ -89,6 +90,11 @@ module.exports = Tokamak =
       Utils.detectBinaries()
 
     Utils.watchConfig()
+
+    setTimeout ->
+      SourceUpdater.updateSourceFiles()
+    , 4000
+
 
     # Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
     @subscriptions = new CompositeDisposable

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "atom-package-deps": "^4.0.1",
     "atom-space-pen-views": "^2.0.0",
     "fs-plus": "^2.0.0",
+    "request": "^2.67.0",
+    "tar": "^2.2.1",
     "temp": "^0.8.1",
     "underscore-plus": "^1.0.0"
   },


### PR DESCRIPTION
This isn't ready for merging yet.

Currently, it downloads the nightly source from Rust's website to the appData/tokamak/ directory, then ungzip and untars it to the /tokamak/rust-sources directory, and makes use of a [progress notification](https://streamable.com/e/w3sz).

Stuff left to do:

- [ ] Point Racer to the correct directory for the updated files.
- [ ] Set up configuration for the updater. We'll probably want to support three different groups of users; one who will just let the autoupdater manage everything, another who will want to set the source directory path but let the autoupdater do the rest, and lastly those who would want to manually manage their source files and turn off the auto updater.
- [ ] Move file downloading and extracting to a temporary directory and perform some sort of file validation on the downloaded file.