### PR TITLE
Don’t add start/end spacers

### DIFF
--- a/lib/tokamak.coffee
+++ b/lib/tokamak.coffee
@@ -112,8 +112,6 @@ module.exports = Tokamak =
   consumeToolBar: (toolBar) ->
     @toolBar = toolBar 'tokamak'
 
-    @toolBar.addSpacer()
-
     @toolBar.addButton
       icon: 'package'
       callback: 'tokamak:create-project'
@@ -172,8 +170,6 @@ module.exports = Tokamak =
       icon: 'ion ion-nuclear'
       callback: 'tokamak:about'
       tooltip: 'About Tokamak'
-
-    @toolBar.addSpacer()
 
     @toolBar.onDidDestroy ->
       @toolBar = null


### PR DESCRIPTION
There’s no reason to have one that isn’t between toolbar buttons, and it breaks material-ui