### PR TITLE
Fix crash in tool-bar caused by tokamak config

### DIFF
--- a/lib/tokamak.coffee
+++ b/lib/tokamak.coffee
@@ -122,27 +122,32 @@ module.exports = Tokamak =
     @toolBar.addSpacer()
 
     @toolBar.addButton
-      icon: 'ion ion-hammer'
+      iconset: 'ion'
+      icon: 'hammer'
       callback: 'tokamak:build'
       tooltip: 'Build'
 
     @toolBar.addButton
-      icon: 'fi fi-x'
+      iconset: 'fi'
+      icon: 'x'
       callback: 'tokamak:clean'
       tooltip: 'Clean'
 
     @toolBar.addButton
-      icon: 'ion ion-refresh'
+      iconset: 'ion'
+      icon: 'refresh'
       callback: 'tokamak:rebuild'
       tooltip: 'Rebuild'
 
     @toolBar.addButton
-      icon: 'ion ion-play'
+      iconset: 'ion'
+      icon: 'play'
       callback: 'tokamak:run'
       tooltip: 'Cargo Run'
 
     @toolBar.addButton
-      icon: 'fi fi-check'
+      iconset: 'fi'
+      icon: 'check'
       callback: 'tokamak:test'
       tooltip: 'Cargo Test'
 
@@ -169,7 +174,8 @@ module.exports = Tokamak =
       tooltip: 'Settings'
 
     @toolBar.addButton
-      icon: 'ion ion-nuclear'
+      iconset: 'ion'
+      icon: 'nuclear'
       callback: 'tokamak:about'
       tooltip: 'About Tokamak'
 


### PR DESCRIPTION
When starting atom, an exception was thrown in tool-bar-button-view.js.
The root cause is that the format of this config file doesn't satisfy the current tool-bar API.

For a complete explanation, please read this issue that was raised against tool-bar:
https://github.com/suda/tool-bar/issues/148#issuecomment-230169317