### PR TITLE
Fixes #72 ReferenceError: mode is not defined

### DIFF
--- a/lib/cargo-view.coffee
+++ b/lib/cargo-view.coffee
@@ -54,7 +54,7 @@ class CargoView extends View
     @panel ?= atom.workspace.addModalPanel(item: this, visible: false)
     @previouslyFocusedElement = $(document.activeElement)
     @panel.show()
-    @message.text("Enter cargo #{mode} project path")
+    @message.text("Enter cargo #{@mode} project path")
     editor = @miniEditor.getModel()
     editor.setText(process.env.HOME)
     @miniEditor.focus()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tokamak",
   "main": "./lib/tokamak",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Fusion Reactor for Rust - Atom Rust IDE",
   "keywords": [],
   "author": "Mahmut Bulut <vertexclique@gmail.com>",


### PR DESCRIPTION
Seems to be simple fix. `mode` appears to be on defined as a property on `this`, but the code referenced a locally scoped `mode` instead.