### PR TITLE
Fixes #52 The path autodetection procedure results contain extra endline symbols

### DIFF
--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -76,15 +76,13 @@ class Utils
             })
 
   @findBinary: (pkg) ->
-    if process.platform is "win32"
-      return @runCommandOut("where", [pkg]);
-    else
-      data = @runCommandOut("which", [pkg]);
+    command = if process.platform is "win32" then "where" else "which"
+    data = @runCommandOut(command, [pkg]);
 
-      if data.status == 0 && data.stdoutData.length >= 0
-        data.stdoutData = data.stdoutData.replace(/^\s+|\s+$/g, "")
+    if data.status == 0 && data.stdoutData.length >= 0
+      data.stdoutData = data.stdoutData.replace(/^\s+|\s+$/g, "")
 
-      return data
+    return data
 
   @watchConfig: ->
     atom.config.onDidChange "tokamak.autocompleteBlacklist", ({newValue, oldValue}) ->


### PR DESCRIPTION
The issue description itself explains its cause pretty well.

As a consequence of the issue, any of `rustup`, `cargo`, or `racer` commands didn't work. Just as a side note, because @dizergin didn't mention it...