### PR TITLE
Don't Hard Code Tab Lengths

### DIFF
--- a/settings/rust.cson
+++ b/settings/rust.cson
@@ -10,6 +10,5 @@
        ^ \\s* (\\s* /[*] .* [*]/ \\s*)* \\}
       |^ \\s* (\\s* /[*] .* [*]/ \\s*)* \\)
       '
-    'tabLength': 2
     'softTabs': true
     'preferredLineLength': 80


### PR DESCRIPTION
A package should never enforce a tab length that ignores what the user has defined. In addition, a tab length of 2 violates Rust formatting standards.

Closes #69